### PR TITLE
Add --db option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ A simple database and query interface for the microbial archive
 
 ```
 pip install .
-export MARC_DB_URL=sqlite:////path/to/db.sqlite
+export MARC_DB_URL=sqlite:////path/to/db.sqlite  # optional environment variable
 marc_db -h
-marc_db ingest /path/to/data_anonymized.tsv
+marc_db --db sqlite:////path/to/db.sqlite ingest /path/to/data_anonymized.tsv
 ```
 
 This will create a new database at `/path/to/db.sqlite` and ingest the anonymized data from marc_honest at `/path/to/data_anonymized.tsv`.

--- a/marc_db/cli.py
+++ b/marc_db/cli.py
@@ -1,7 +1,7 @@
 import argparse
 import sys
 from marc_db import __version__
-from marc_db.db import create_database
+from marc_db.db import create_database, get_session, get_marc_db_url
 from marc_db.ingest import ingest_tsv
 from marc_db.mock import fill_mock_db
 
@@ -31,13 +31,20 @@ def main():
         action="version",
         version=__version__,
     )
+    parser.add_argument(
+        "--db",
+        help="Database URL to use instead of MARC_DB_URL",
+        default=None,
+    )
 
     args, remaining = parser.parse_known_args()
 
+    db_url = args.db or get_marc_db_url()
+
     if args.command == "init":
-        create_database()
+        create_database(db_url)
     elif args.command == "mock_db":
-        fill_mock_db()
+        fill_mock_db(get_session(db_url))
     elif args.command == "ingest":
         parser_ingest = argparse.ArgumentParser(
             prog="marc_db ingest",
@@ -46,7 +53,7 @@ def main():
         )
         parser_ingest.add_argument("file_path", help="Path to the file to ingest.")
         args_ingest = parser_ingest.parse_args(remaining)
-        ingest_tsv(args_ingest.file_path)
+        ingest_tsv(args_ingest.file_path, get_session(db_url))
     else:
         parser.print_help()
         sys.stderr.write("Unrecognized command.\n")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,13 @@
+import subprocess
+import sys
+from pathlib import Path
+
+def test_cli_db_arg():
+    file_path = Path(__file__).parent / "test_anonymized.tsv"
+    result = subprocess.run(
+        [sys.executable, "-m", "marc_db.cli", "--db", "sqlite:///:memory:", "ingest", str(file_path)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary
- allow CLI users to pass a `--db` URL instead of relying on MARC_DB_URL
- document new option in README
- add regression test for the CLI `--db` argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686571c2bf5c8323a626bbe9231189b9