### PR TITLE
Improve ingestion with duplicate isolation handling

### DIFF
--- a/tests/test_bad_duplicates.tsv
+++ b/tests/test_bad_duplicates.tsv
@@ -1,0 +1,3 @@
+SampleID	sample species	Received by mARC	Cryobanking	sample_source	Note	Technician	special_collection	Tube Type	Tube Barcode	Box-name_position	Subject ID	Specimen ID
+sample1	Unknown	2022-01-01	2022-01-02	blood culture		TechA	a	NA	barcode1A	Box1	1	101
+sample1	Unknown	2022-01-01	2022-01-02	blood culture		TechA	a	NA	barcode1B	Box1	2	101

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 
 def test_cli_db_arg():
-    file_path = Path(__file__).parent / "test_anonymized.tsv"
+    file_path = Path(__file__).parent / "test_multi_aliquot.tsv"
     result = subprocess.run(
         [sys.executable, "-m", "marc_db.cli", "--db", "sqlite:///:memory:", "ingest", str(file_path)],
         stdout=subprocess.PIPE,

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -25,7 +25,7 @@ def session(engine):
 @pytest.fixture(scope="module")
 def ingest(session):
     # Ingest the tsv file without error
-    df = ingest_tsv(Path(__file__).parent / "test_anonymized.tsv", session)
+    df = ingest_tsv(Path(__file__).parent / "test_multi_aliquot.tsv", session)
     return df, session
 
 
@@ -40,5 +40,10 @@ def test_views(ingest):
     assert len(get_isolates(session)) > 0
     assert len(get_aliquots(session)) > 0
 
-    assert len(get_isolates(session, sample_id="marc.bacteremia.1")) == 1
+    assert len(get_isolates(session, sample_id="sample1")) == 1
     assert len(get_aliquots(session, id=1)) == 1
+
+
+def test_inconsistent_duplicate_rows(session):
+    with pytest.raises(ValueError):
+        ingest_tsv(Path(__file__).parent / "test_bad_duplicates.tsv", session)

--- a/tests/test_multi_aliquot.tsv
+++ b/tests/test_multi_aliquot.tsv
@@ -1,0 +1,6 @@
+SampleID	sample species	Received by mARC	Cryobanking	sample_source	Note	Technician	special_collection	Tube Type	Tube Barcode	Box-name_position	Subject ID	Specimen ID
+sample1	Unknown	2022-01-01	2022-01-02	blood culture		TechA	a	NA	barcode1A	Box1	1	101
+sample1	Unknown	2022-01-01	2022-01-02	blood culture		TechA	a	NA	barcode1B	Box1	1	101
+sample1	Unknown	2022-01-01	2022-01-02	blood culture		TechA	a	NA	barcode1C	Box1	1	101
+sample2	K. pneumonia	2022-01-03	2022-01-04	nasal swab		TechB	a	NA	barcode2A	Box2	2	201
+sample2	K. pneumonia	2022-01-03	2022-01-04	nasal swab		TechB	a	NA	barcode2B	Box2	2	201


### PR DESCRIPTION
## Summary
- handle duplicate isolate rows during ingestion
- update ingestion tests to use sample data with multiple aliquots per isolate
- add failing test case for inconsistent duplicates
- update CLI test to use new dataset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bfa16bb948323ba93a6b33f522f5c