### PR TITLE
Fix --db option precedence

### DIFF
--- a/marc_db/db.py
+++ b/marc_db/db.py
@@ -6,26 +6,24 @@ from marc_db.models import Base
 
 
 def get_marc_db_url() -> str:
-    try:
-        os.environ["MARC_DB_URL"]
-    except KeyError:
-        print("MARC_DB_URL environment variable not set, using in-memory db")
-        return "sqlite:///:memory:"
-    return os.environ["MARC_DB_URL"]
+    """Return the database URL from ``MARC_DB_URL`` or fallback to in-memory."""
+    return os.environ.get("MARC_DB_URL", "sqlite:///:memory:")
 
 
-def create_database(database_url: str = get_marc_db_url()):
+def create_database(database_url: str | None = None):
     """
     Create the database tables that don't exist using the provided database URL.
 
     Parameters:
     database_url (str): The database URL.
     """
+    if database_url is None:
+        database_url = get_marc_db_url()
     engine = create_engine(database_url)
     Base.metadata.create_all(engine, checkfirst=True)
 
 
-def get_connection(database_url: str = get_marc_db_url()) -> Connection:
+def get_connection(database_url: str | None = None) -> Connection:
     """
     Get a connection to the database using the provided database URL.
 
@@ -35,12 +33,14 @@ def get_connection(database_url: str = get_marc_db_url()) -> Connection:
     Returns:
     connection: The connection to the database.
     """
+    if database_url is None:
+        database_url = get_marc_db_url()
     engine = create_engine(database_url)
     connection = engine.connect()
     return connection
 
 
-def get_session(database_url: str = get_marc_db_url()) -> Session:
+def get_session(database_url: str | None = None) -> Session:
     """
     Get a session to the database using the provided database URL.
 
@@ -52,6 +52,8 @@ def get_session(database_url: str = get_marc_db_url()) -> Session:
     """
     from sqlalchemy.orm import sessionmaker
 
+    if database_url is None:
+        database_url = get_marc_db_url()
     engine = create_engine(database_url)
     Session = sessionmaker(bind=engine)
     session = Session()

--- a/marc_db/mock.py
+++ b/marc_db/mock.py
@@ -37,7 +37,9 @@ aliquot7 = Aliquot(isolate_id="sample3", tube_barcode="129", box_name="box1")
 aliquot8 = Aliquot(isolate_id="sample3", tube_barcode="130", box_name="box1")
 
 
-def fill_mock_db(session: Session = get_session()):
+def fill_mock_db(session: Session | None = None):
+    if session is None:
+        session = get_session()
     # Check that db is an empty test db
     assert (
         len(session.query(Isolate).all()) == 0

--- a/marc_db/views.py
+++ b/marc_db/views.py
@@ -4,8 +4,10 @@ from sqlalchemy.orm import Session
 
 
 def get_isolates(
-    session: Session = get_session(), sample_id: str = None, n: int = None
+    session: Session | None = None, sample_id: str | None = None, n: int | None = None
 ) -> list[Isolate]:
+    if session is None:
+        session = get_session()
     """
     Get a list of Isolate objects from the database.
 
@@ -21,8 +23,10 @@ def get_isolates(
 
 
 def get_aliquots(
-    session: Session = get_session(), id: int = None, n: int = None
+    session: Session | None = None, id: int | None = None, n: int | None = None
 ) -> list[Aliquot]:
+    if session is None:
+        session = get_session()
     """
     Get a list of Aliquot objects from the database.
 


### PR DESCRIPTION
## Summary
- ensure environment variable isn't resolved at import time
- clean up fallback logic for `MARC_DB_URL`
- allow CLI `--db` flag to reliably override environment variable

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713ba277f88323b192a2bc41bcb308