### PR TITLE
Add assembly ingestion

### DIFF
--- a/marc_db/cli.py
+++ b/marc_db/cli.py
@@ -2,7 +2,7 @@ import argparse
 import sys
 from marc_db import __version__
 from marc_db.db import create_database, get_session, get_marc_db_url
-from marc_db.ingest import ingest_tsv
+from marc_db.ingest import ingest_tsv, ingest_assembly_tsv
 from marc_db.mock import fill_mock_db
 
 
@@ -13,6 +13,7 @@ def main():
         "  init         \tInitialize a new database.\n"
         "  mock_db      \tFill mock values into an empty db (for testing).\n"
         "  ingest       \tIngest data from a file into the database.\n"
+        "  ingest_assembly\tIngest assembly-related data.\n"
     )
 
     parser = argparse.ArgumentParser(
@@ -54,6 +55,33 @@ def main():
         parser_ingest.add_argument("file_path", help="Path to the file to ingest.")
         args_ingest = parser_ingest.parse_args(remaining)
         ingest_tsv(args_ingest.file_path, get_session(db_url))
+    elif args.command == "ingest_assembly":
+        parser_asm = argparse.ArgumentParser(
+            prog="marc_db ingest_assembly",
+            usage="%(prog)s <file_path> [options]",
+            description="Ingest assembly related data from a tsv into the database.",
+        )
+        parser_asm.add_argument("file_path", help="Path to the file to ingest.")
+        parser_asm.add_argument("--metagenomic-sample-id")
+        parser_asm.add_argument("--metagenomic-run-id")
+        parser_asm.add_argument("--run-number")
+        parser_asm.add_argument("--sunbeam-version")
+        parser_asm.add_argument("--sbx-sga-version")
+        parser_asm.add_argument("--config-file")
+        parser_asm.add_argument("--sunbeam-output-path")
+        args_asm = parser_asm.parse_args(remaining)
+        create_database(db_url)
+        ingest_assembly_tsv(
+            args_asm.file_path,
+            metagenomic_sample_id=args_asm.metagenomic_sample_id,
+            metagenomic_run_id=args_asm.metagenomic_run_id,
+            run_number=args_asm.run_number,
+            sunbeam_version=args_asm.sunbeam_version,
+            sbx_sga_version=args_asm.sbx_sga_version,
+            config_file=args_asm.config_file,
+            sunbeam_output_path=args_asm.sunbeam_output_path,
+            session=get_session(db_url),
+        )
     else:
         parser.print_help()
         sys.stderr.write("Unrecognized command.\n")

--- a/marc_db/ingest.py
+++ b/marc_db/ingest.py
@@ -1,6 +1,13 @@
 import pandas as pd
 from marc_db.db import get_session
-from marc_db.models import Aliquot, Isolate
+from marc_db.models import (
+    Aliquot,
+    Isolate,
+    Assembly,
+    AssemblyQC,
+    TaxonomicAssignment,
+    Antimicrobial,
+)
 from sqlalchemy.orm import Session
 from typing import Optional
 
@@ -95,4 +102,88 @@ def ingest_tsv(file_path: str, session: Optional[Session] = None) -> pd.DataFram
         f"Aliquots added: {added_aliquots} success, {failed_aliquots} failed"
     )
 
+    return df
+
+
+def ingest_assembly_tsv(
+    file_path: str,
+    *,
+    metagenomic_sample_id: Optional[str] = None,
+    metagenomic_run_id: Optional[str] = None,
+    run_number: Optional[str] = None,
+    sunbeam_version: Optional[str] = None,
+    sbx_sga_version: Optional[str] = None,
+    config_file: Optional[str] = None,
+    sunbeam_output_path: Optional[str] = None,
+    session: Optional[Session] = None,
+) -> pd.DataFrame:
+    """Ingest assembly related data from ``file_path``.
+
+    The TSV must contain a ``Sample`` column referencing existing
+    ``Isolate.sample_id`` values. All assembly level metadata is supplied via
+    function arguments. Rows are interpreted as antimicrobial gene entries with
+    accompanying QC and taxonomic information which are collapsed per sample.
+    """
+
+    if session is None:
+        session = get_session()
+
+    df = pd.read_csv(file_path, sep="\t")
+
+    for sample, g in df.groupby("Sample"):
+        asm = Assembly(
+            isolate_id=sample,
+            metagenomic_sample_id=metagenomic_sample_id,
+            metagenomic_run_id=metagenomic_run_id,
+            run_number=run_number,
+            sunbeam_version=sunbeam_version,
+            sbx_sga_version=sbx_sga_version,
+            config_file=config_file,
+            sunbeam_output_path=sunbeam_output_path,
+        )
+        session.add(asm)
+        session.flush()  # populate asm.id
+
+        first = g.iloc[0]
+        qc = AssemblyQC(
+            assembly_id=asm.id,
+            isolate_id=sample,
+            contig_count=first.get("contig_count"),
+            genome_size=first.get("genome_size"),
+            n50=first.get("n50"),
+            gc_content=first.get("gc_content"),
+            cds=first.get("cds"),
+            completeness=first.get("completeness"),
+            contamination=first.get("contamination"),
+            min_contig_coverage=first.get("min_contig_coverage"),
+            avg_contig_coverage=first.get("avg_contig_coverage"),
+            max_contig_coverage=first.get("max_contig_coverage"),
+        )
+        session.add(qc)
+
+        tax = TaxonomicAssignment(
+            assembly_id=asm.id,
+            isolate_id=sample,
+            taxonomic_classification=first.get("taxonomic_classification"),
+            taxonomic_abundance=first.get("taxonomic_abundance"),
+            st=first.get("st"),
+            st_schema=first.get("st_schema"),
+            allele_assignment=first.get("allele_assignment"),
+        )
+        session.add(tax)
+
+        for _, row in g.iterrows():
+            amr = Antimicrobial(
+                assembly_id=asm.id,
+                isolate_id=sample,
+                contig_id=row.get("contig_id"),
+                gene_symbol=row.get("gene_symbol"),
+                gene_name=row.get("gene_name"),
+                accession=row.get("accession"),
+                element_type=row.get("element_type"),
+                resistance_product=row.get("resistance_product"),
+            )
+            session.add(amr)
+
+    session.commit()
     return df

--- a/tests/test_assembly_data.tsv
+++ b/tests/test_assembly_data.tsv
@@ -1,0 +1,3 @@
+Sample	contig_count	genome_size	n50	gc_content	cds	completeness	contamination	min_contig_coverage	avg_contig_coverage	max_contig_coverage	taxonomic_classification	taxonomic_abundance	st	st_schema	allele_assignment	contig_id	gene_symbol	gene_name	accession	element_type	resistance_product
+sample1	10	5000000	30000	50.0	4500	99.0	1.0	10	20	30	Escherichia coli	0.9	ST1	schema1	allele1	c1	blaA	geneA	acc1	plasmid	protein1
+sample2	20	6000000	40000	51.0	4600	98.0	2.0	15	25	35	Klebsiella pneumoniae	0.8	ST2	schema2	allele2	c3	blaC	geneC	acc3	chromosome	enzyme3

--- a/tests/test_assembly_ingest.py
+++ b/tests/test_assembly_ingest.py
@@ -1,0 +1,43 @@
+import pytest
+from pathlib import Path
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from marc_db.models import Base, Isolate, Assembly, AssemblyQC, TaxonomicAssignment, Antimicrobial
+from marc_db.ingest import ingest_tsv, ingest_assembly_tsv
+
+
+@pytest.fixture(scope="module")
+def engine():
+    return create_engine("sqlite:///:memory:")
+
+
+@pytest.fixture(scope="module")
+def session(engine):
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    Base.metadata.create_all(engine)
+    yield session
+    session.close()
+
+
+@pytest.fixture(scope="module")
+def ingest_data(session):
+    ingest_tsv(Path(__file__).parent / "test_multi_aliquot.tsv", session)
+    df = ingest_assembly_tsv(
+        Path(__file__).parent / "test_assembly_data.tsv",
+        run_number="1",
+        sunbeam_version="v1",
+        sbx_sga_version="v1",
+        config_file="cfg",
+        sunbeam_output_path="/sb",
+        session=session,
+    )
+    return df, session
+
+
+def test_counts(ingest_data):
+    _, session = ingest_data
+    assert session.query(Assembly).count() == 2
+    assert session.query(AssemblyQC).count() == 2
+    assert session.query(TaxonomicAssignment).count() == 2
+    assert session.query(Antimicrobial).count() == 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,3 +20,24 @@ def test_cli_db_arg():
         text=True,
     )
     assert result.returncode == 0
+
+
+def test_cli_ingest_assembly():
+    file_path = Path(__file__).parent / "test_assembly_data.tsv"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "marc_db.cli",
+            "--db",
+            "sqlite:///:memory:",
+            "ingest_assembly",
+            str(file_path),
+            "--run-number",
+            "1",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary
- add ingestion routine for assembly models
- extend CLI with new `ingest_assembly` command
- test ingesting new assembly data tables
- provide sample TSV for assembly ingestion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687958982f908323979ad5dec6f62998