### PR TITLE
Add assembly views and relationships

### DIFF
--- a/marc_db/models.py
+++ b/marc_db/models.py
@@ -59,7 +59,9 @@ class Assembly(Base):
 
     isolate = relationship("Isolate", back_populates="assemblies")
     assembly_qcs = relationship("AssemblyQC", back_populates="assembly", uselist=False)
-    taxonomic_assignments = relationship("TaxonomicAssignment", back_populates="assembly")
+    taxonomic_assignments = relationship(
+        "TaxonomicAssignment", back_populates="assembly"
+    )
     antimicrobials = relationship("Antimicrobial", back_populates="assembly")
 
 
@@ -67,7 +69,7 @@ class AssemblyQC(Base):
     __tablename__ = "assembly_qc"
 
     assembly_id = Column(Integer, ForeignKey("assemblies.id"), primary_key=True)
-    assembly = relationship("Assembly", back_populates="assembly_qc")
+    assembly = relationship("Assembly", back_populates="assembly_qcs")
     contig_count = Column(Integer)
     genome_size = Column(Integer)
     n50 = Column(Integer)

--- a/marc_db/models.py
+++ b/marc_db/models.py
@@ -7,7 +7,7 @@ from sqlalchemy import (
     ForeignKey,
     UniqueConstraint,
 )
-from sqlalchemy.orm import declarative_base
+from sqlalchemy.orm import declarative_base, relationship
 
 Base = declarative_base()
 
@@ -23,6 +23,8 @@ class Isolate(Base):
     special_collection = Column(Text)
     received_date = Column(Date, nullable=True)
     cryobanking_date = Column(Date, nullable=True)
+
+    assemblies = relationship("Assembly", back_populates="isolate")
 
 
 class Aliquot(Base):
@@ -55,12 +57,17 @@ class Assembly(Base):
     config_file = Column(Text)
     sunbeam_output_path = Column(Text)
 
+    isolate = relationship("Isolate", back_populates="assemblies")
+    assembly_qc = relationship("AssemblyQC", back_populates="assembly", uselist=False)
+    taxonomic_assignments = relationship("TaxonomicAssignment", back_populates="assembly")
+    antimicrobials = relationship("Antimicrobial", back_populates="assembly")
+
 
 class AssemblyQC(Base):
     __tablename__ = "assembly_qc"
 
     assembly_id = Column(Integer, ForeignKey("assemblies.id"), primary_key=True)
-    isolate_id = Column(Text, ForeignKey("isolates.sample_id"))
+    assembly = relationship("Assembly", back_populates="assembly_qc")
     contig_count = Column(Integer)
     genome_size = Column(Integer)
     n50 = Column(Integer)
@@ -77,7 +84,7 @@ class TaxonomicAssignment(Base):
     __tablename__ = "taxonomic_assignments"
 
     assembly_id = Column(Integer, ForeignKey("assemblies.id"), primary_key=True)
-    isolate_id = Column(Text, ForeignKey("isolates.sample_id"))
+    assembly = relationship("Assembly", back_populates="taxonomic_assignments")
     taxonomic_classification = Column(Text)
     taxonomic_abundance = Column(Float)
     st = Column(Text)
@@ -89,7 +96,7 @@ class Antimicrobial(Base):
     __tablename__ = "antimicrobials"
 
     assembly_id = Column(Integer, ForeignKey("assemblies.id"), primary_key=True)
-    isolate_id = Column(Text, ForeignKey("isolates.sample_id"))
+    assembly = relationship("Assembly", back_populates="antimicrobials")
     contig_id = Column(Text)
     gene_symbol = Column(Text)
     gene_name = Column(Text)

--- a/marc_db/models.py
+++ b/marc_db/models.py
@@ -58,7 +58,7 @@ class Assembly(Base):
     sunbeam_output_path = Column(Text)
 
     isolate = relationship("Isolate", back_populates="assemblies")
-    assembly_qc = relationship("AssemblyQC", back_populates="assembly", uselist=False)
+    assembly_qcs = relationship("AssemblyQC", back_populates="assembly", uselist=False)
     taxonomic_assignments = relationship("TaxonomicAssignment", back_populates="assembly")
     antimicrobials = relationship("Antimicrobial", back_populates="assembly")
 

--- a/marc_db/views.py
+++ b/marc_db/views.py
@@ -99,5 +99,6 @@ def get_antimicrobials(
         session = get_session()
     query = session.query(Antimicrobial, Assembly.isolate_id).join(Assembly)
     if assembly_id:
-        return [query.filter(Antimicrobial.assembly_id == assembly_id).first()]
+        result = query.filter(Antimicrobial.assembly_id == assembly_id).first()
+        return [result] if result else []
     return query.limit(n).all()

--- a/marc_db/views.py
+++ b/marc_db/views.py
@@ -73,7 +73,8 @@ def get_assembly_qc(
         session = get_session()
     query = session.query(AssemblyQC, Assembly.isolate_id).join(Assembly)
     if assembly_id:
-        return [query.filter(AssemblyQC.assembly_id == assembly_id).first()]
+        result = query.filter(AssemblyQC.assembly_id == assembly_id).first()
+        return [result] if result else []
     return query.limit(n).all()
 
 
@@ -86,7 +87,8 @@ def get_taxonomic_assignments(
         session = get_session()
     query = session.query(TaxonomicAssignment, Assembly.isolate_id).join(Assembly)
     if assembly_id:
-        return [query.filter(TaxonomicAssignment.assembly_id == assembly_id).first()]
+        result = query.filter(TaxonomicAssignment.assembly_id == assembly_id).first()
+        return [result] if result else []
     return query.limit(n).all()
 
 

--- a/marc_db/views.py
+++ b/marc_db/views.py
@@ -1,6 +1,13 @@
 from typing import Optional
 from marc_db.db import get_session
-from marc_db.models import Aliquot, Isolate
+from marc_db.models import (
+    Aliquot,
+    Isolate,
+    Assembly,
+    AssemblyQC,
+    TaxonomicAssignment,
+    Antimicrobial,
+)
 from sqlalchemy.orm import Session
 
 
@@ -42,3 +49,54 @@ def get_aliquots(
     if id:
         return [session.query(Aliquot).filter(Aliquot.id == id).first()]
     return session.query(Aliquot).limit(n).all()
+
+
+def get_assemblies(
+    session: Optional[Session] = None,
+    id: Optional[int] = None,
+    n: Optional[int] = None,
+) -> list[Assembly]:
+    if session is None:
+        session = get_session()
+    if id:
+        return [session.query(Assembly).filter(Assembly.id == id).first()]
+    return session.query(Assembly).limit(n).all()
+
+
+def get_assembly_qc(
+    session: Optional[Session] = None,
+    assembly_id: Optional[int] = None,
+    n: Optional[int] = None,
+) -> list[tuple[AssemblyQC, str]]:
+    if session is None:
+        session = get_session()
+    query = session.query(AssemblyQC, Assembly.isolate_id).join(Assembly)
+    if assembly_id:
+        return [query.filter(AssemblyQC.assembly_id == assembly_id).first()]
+    return query.limit(n).all()
+
+
+def get_taxonomic_assignments(
+    session: Optional[Session] = None,
+    assembly_id: Optional[int] = None,
+    n: Optional[int] = None,
+) -> list[tuple[TaxonomicAssignment, str]]:
+    if session is None:
+        session = get_session()
+    query = session.query(TaxonomicAssignment, Assembly.isolate_id).join(Assembly)
+    if assembly_id:
+        return [query.filter(TaxonomicAssignment.assembly_id == assembly_id).first()]
+    return query.limit(n).all()
+
+
+def get_antimicrobials(
+    session: Optional[Session] = None,
+    assembly_id: Optional[int] = None,
+    n: Optional[int] = None,
+) -> list[tuple[Antimicrobial, str]]:
+    if session is None:
+        session = get_session()
+    query = session.query(Antimicrobial, Assembly.isolate_id).join(Assembly)
+    if assembly_id:
+        return [query.filter(Antimicrobial.assembly_id == assembly_id).first()]
+    return query.limit(n).all()

--- a/marc_db/views.py
+++ b/marc_db/views.py
@@ -59,7 +59,8 @@ def get_assemblies(
     if session is None:
         session = get_session()
     if id:
-        return [session.query(Assembly).filter(Assembly.id == id).first()]
+        result = session.query(Assembly).filter(Assembly.id == id).first()
+        return [result] if result else []
     return session.query(Assembly).limit(n).all()
 
 

--- a/tests/test_new_views.py
+++ b/tests/test_new_views.py
@@ -2,7 +2,14 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from marc_db.models import Base, Isolate, Assembly, AssemblyQC, TaxonomicAssignment, Antimicrobial
+from marc_db.models import (
+    Base,
+    Isolate,
+    Assembly,
+    AssemblyQC,
+    TaxonomicAssignment,
+    Antimicrobial,
+)
 from marc_db.views import (
     get_assemblies,
     get_assembly_qc,
@@ -36,7 +43,9 @@ def setup_data(session):
     session.commit()
 
     qc = AssemblyQC(assembly_id=assembly.id, contig_count=10)
-    tax = TaxonomicAssignment(assembly_id=assembly.id, taxonomic_classification="k__Bacteria")
+    tax = TaxonomicAssignment(
+        assembly_id=assembly.id, taxonomic_classification="k__Bacteria"
+    )
     amr = Antimicrobial(assembly_id=assembly.id, gene_symbol="blaCTX")
     session.add_all([qc, tax, amr])
     session.commit()

--- a/tests/test_new_views.py
+++ b/tests/test_new_views.py
@@ -1,0 +1,61 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from marc_db.models import Base, Isolate, Assembly, AssemblyQC, TaxonomicAssignment, Antimicrobial
+from marc_db.views import (
+    get_assemblies,
+    get_assembly_qc,
+    get_taxonomic_assignments,
+    get_antimicrobials,
+)
+
+
+@pytest.fixture(scope="module")
+def engine():
+    return create_engine("sqlite:///:memory:")
+
+
+@pytest.fixture(scope="module")
+def session(engine):
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    Base.metadata.create_all(engine)
+    yield session
+    session.close()
+
+
+@pytest.fixture(scope="module")
+def setup_data(session):
+    iso = Isolate(sample_id="iso1", subject_id=1, specimen_id=1)
+    session.add(iso)
+    session.commit()
+
+    assembly = Assembly(isolate_id=iso.sample_id, metagenomic_sample_id="ms1")
+    session.add(assembly)
+    session.commit()
+
+    qc = AssemblyQC(assembly_id=assembly.id, contig_count=10)
+    tax = TaxonomicAssignment(assembly_id=assembly.id, taxonomic_classification="k__Bacteria")
+    amr = Antimicrobial(assembly_id=assembly.id, gene_symbol="blaCTX")
+    session.add_all([qc, tax, amr])
+    session.commit()
+    return iso, assembly, qc, tax, amr
+
+
+def test_new_views(session, setup_data):
+    iso, assembly, qc, tax, amr = setup_data
+
+    assert get_assemblies(session)[0].id == assembly.id
+
+    qc_res, iso_id = get_assembly_qc(session)[0]
+    assert qc_res.contig_count == qc.contig_count
+    assert iso_id == iso.sample_id
+
+    tax_res, iso_id = get_taxonomic_assignments(session)[0]
+    assert tax_res.taxonomic_classification == tax.taxonomic_classification
+    assert iso_id == iso.sample_id
+
+    amr_res, iso_id = get_antimicrobials(session)[0]
+    assert amr_res.gene_symbol == amr.gene_symbol
+    assert iso_id == iso.sample_id


### PR DESCRIPTION
## Summary
- remove unused `isolate_id` columns
- define relationships between assemblies and related tables
- expose `get_assemblies`, `get_assembly_qc`, `get_taxonomic_assignments`, `get_antimicrobials` views
- test new views

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e958c0528832385ed43a3b1dcdc27